### PR TITLE
Fix split flag usage

### DIFF
--- a/packages/claudepilot/cmd/create.go
+++ b/packages/claudepilot/cmd/create.go
@@ -26,7 +26,7 @@ Examples:
   claude-pilot create --project ./src              # Create session with project path
   claude-pilot create --attach-to main --as-pane   # Create as new pane in 'main' session
   claude-pilot create --attach-to main --as-window # Create as new window in 'main' session
-  claude-pilot create debug --attach-to main --as-pane --split-h  # Create horizontal pane split
+  claude-pilot create debug --attach-to main --as-pane --split h  # Create horizontal pane split
   `,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
## Summary
- correct split pane example in `create` command usage

## Testing
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68813424550c832dbfeeeca805fc4122