### PR TITLE
Set default backend to auto

### DIFF
--- a/packages/core/internal/config/config.go
+++ b/packages/core/internal/config/config.go
@@ -75,8 +75,8 @@ type LoggingConfig struct {
 // DefaultConfig returns a configuration with sensible defaults
 func DefaultConfig() *Config {
 	homeDir, _ := os.UserHomeDir()
-	return &Config{
-		Backend:      "tmux", // Auto-detect available backend
+        return &Config{
+                Backend:      "auto", // Auto-detect available backend
 		BackendPath:  "",     // Use system PATH
 		SessionsDir:  filepath.Join(homeDir, ".config", "claude-pilot", "sessions"),
 		DefaultShell: "claude",
@@ -310,8 +310,8 @@ func (cm *ConfigManager) createDefaultConfigFileAt(configFilePath string) error 
 #
 # For more information, visit: https://github.com/HexSleeves/claude-pilot
 
-# Backend selection: tmux
-backend: tmux
+# Backend selection: auto
+backend: auto
 
 # Directory where session metadata is stored
 # Will be created automatically if it doesn't exist

--- a/packages/core/internal/config/config_test.go
+++ b/packages/core/internal/config/config_test.go
@@ -102,7 +102,7 @@ func TestBackendConfig(t *testing.T) {
 	}
 
 	// Test valid backends
-	validBackends := []string{"tmux"}
+        validBackends := []string{"tmux", "auto"}
 	found := slices.Contains(validBackends, config.Backend)
 	if !found {
 		t.Errorf("Default backend '%s' should be one of: %v", config.Backend, validBackends)


### PR DESCRIPTION
## Summary
- default to auto backend in config
- allow `auto` in backend validation test

## Testing
- `make test`
- `cd packages/core && go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68813426257c832dafb8192207809d8d